### PR TITLE
fix: back up corrupt config during uninstall

### DIFF
--- a/scripts/preuninstall.ts
+++ b/scripts/preuninstall.ts
@@ -314,8 +314,12 @@ function removeFromConfig(configDir: string): { success: boolean; backupFile: st
 
     const parsed = parseConfigContent(trimmedContent);
     if (parsed.parseError) {
-      log("Failed to parse config, skipping", { error: parsed.parseError, configFile });
-      console.log(`⚠️  Corrupted config detected. Backup saved: ${backupFile}`);
+      backupFile = createBackup(configFile);
+      log("Failed to parse config, skipping", { error: parsed.parseError, configFile, backupFile });
+      console.log(`⚠️  Corrupted config detected. Skipping cleanup for ${configFile}.`);
+      if (backupFile) {
+        console.log(`   Backup saved: ${backupFile}`);
+      }
       return { success: false, backupFile };
     }
     const config = parsed.config ?? {};

--- a/tests/unit/install-hooks.test.ts
+++ b/tests/unit/install-hooks.test.ts
@@ -286,6 +286,29 @@ describe("install hook scripts", () => {
         expect(result.stdout).not.toContain("Backup created:");
     });
 
+    it("preuninstall backs up corrupt config without reporting a null backup path", async () => {
+        await using tmp = await tmpdir({ prefix: "preuninstall-corrupt-" });
+        const configDir = path.join(tmp.path, "xdg", "opencode");
+        const configFile = path.join(configDir, "opencode.jsonc");
+        const corruptContent = "{ invalid json |||";
+        mkdirSync(configDir, { recursive: true });
+        writeFileSync(configFile, corruptContent);
+
+        const result = runNode(
+            ["--experimental-strip-types", preuninstallPath],
+            repoRoot,
+            { XDG_CONFIG_HOME: path.join(tmp.path, "xdg"), HOME: tmp.path }
+        );
+
+        const backupFiles = readdirSync(configDir).filter((entry) => entry.startsWith("opencode.jsonc.backup."));
+        expect(result.status).toBe(0);
+        expect(result.stdout).toContain("Corrupted config detected");
+        expect(result.stdout).not.toContain("Backup saved: null");
+        expect(readFileSync(configFile, "utf8")).toBe(corruptContent);
+        expect(backupFiles).toHaveLength(1);
+        expect(readFileSync(path.join(configDir, backupFiles[0]), "utf8")).toBe(corruptContent);
+    });
+
     it("preuninstall removes only our plugin from jsonc config and preserves comments", async () => {
         await using tmp = await tmpdir({ prefix: "preuninstall-jsonc-" });
         const configDir = path.join(tmp.path, "xdg", "opencode");


### PR DESCRIPTION
## Summary
- create a real backup before skipping cleanup for corrupted OpenCode config files
- avoid printing `Backup saved: null` when preuninstall cannot parse the config
- cover the behavior through the actual `scripts/preuninstall.ts` hook path

## Validation
- red check before the fix: `npx vitest tests/unit/install-hooks.test.ts --reporter=verbose` failed on `Backup saved: null`
- `npx vitest tests/unit/install-hooks.test.ts --reporter=verbose`
- `npm run test:unit`
- `npm run build`