### PR TITLE
fix: skip verification continuation without file work

### DIFF
--- a/src/core/loop/todo-continuation.ts
+++ b/src/core/loop/todo-continuation.ts
@@ -378,7 +378,13 @@ function checkFileWorkForIdle(directory: string): boolean {
 }
 
 function hasFileBasedWork(verification: ReturnType<typeof verifyMissionCompletion>): boolean {
-    return !verification.passed;
+    // A missing TODO/checklist means no file-backed mission exists. Treating the
+    // generic verification failure as work makes every ordinary idle session
+    // invent a mission and inject a false completion gate.
+    const hasTodo = verification.todoProgress !== "0/0";
+    const hasChecklist = verification.checklistPresent;
+    const hasSyncIssues = verification.syncIssuesCount > 0;
+    return !verification.passed && (hasTodo || hasChecklist || hasSyncIssues);
 }
 
 async function startContinuationCountdown(

--- a/tests/unit/todo-continuation.test.ts
+++ b/tests/unit/todo-continuation.test.ts
@@ -302,6 +302,38 @@ describe("TodoContinuation", () => {
             expect(hasPendingContinuation(sessionID)).toBe(false);
         });
 
+        it("does not invent file-based work when no TODO or checklist exists", async () => {
+            mocks.verifyMissionCompletion.mockReturnValue({
+                passed: false,
+                todoIncomplete: 0,
+                todoProgress: "0/0",
+                todoComplete: false,
+                checklistPresent: false,
+                checklistProgress: "0/0",
+                checklistComplete: false,
+                syncIssuesEmpty: true,
+                syncIssuesCount: 0,
+                errors: ["TODO file not found at .opencode/todo.md"],
+            });
+            const client = {
+                session: {
+                    todo: vi.fn().mockResolvedValue({ data: [] }),
+                    prompt: vi.fn().mockResolvedValue({ data: {} }),
+                },
+                tui: {
+                    showToast: vi.fn().mockResolvedValue({ data: true }),
+                },
+            };
+
+            await handleSessionIdle(client as unknown as Parameters<typeof handleSessionIdle>[0], directory, sessionID, sessionID);
+            await vi.advanceTimersByTimeAsync(2000);
+
+            expect(client.session.prompt).not.toHaveBeenCalled();
+            expect(client.tui.showToast).not.toHaveBeenCalled();
+            expect(hasPendingContinuation(sessionID)).toBe(false);
+            expect(mocks.buildVerificationFailurePrompt).not.toHaveBeenCalled();
+        });
+
         it("injects a file-based continuation when SDK todos are complete but file work remains", async () => {
             mocks.verifyMissionCompletion.mockReturnValue({
                 passed: false,


### PR DESCRIPTION
## Summary

- stop `todo-continuation` from treating every failed verification result as file-backed work
- require an actual TODO, checklist, or sync issue before scheduling a continuation
- add a regression test for ordinary idle sessions without `.opencode/todo.md`

## Root cause

`verifyMissionCompletion()` intentionally reports a missing TODO as a failed verification. `hasFileBasedWork()` reduced that result to `!verification.passed`, so an ordinary session with no mission looked like unfinished file-backed work and received a synthetic `<verification_failure>` prompt after becoming idle.

## Behavior after this change

- no TODO/checklist/sync issues: no continuation
- incomplete TODO: continuation remains enabled
- present checklist: continuation remains enabled
- unresolved sync issues: continuation remains enabled

## Test plan

- [x] Regression test fails against `main` with the synthetic verification prompt
- [x] Targeted test: 19/19 passed
- [x] Full suite: 106 files, 942 tests passed
- [x] `npm run build`
- [x] `node --check dist/index.js`
- [x] `git diff --check`
